### PR TITLE
Add a new request parameter in Produce API to allow clients to choose …

### DIFF
--- a/src/main/java/server/KafkaProxyServiceImpl.java
+++ b/src/main/java/server/KafkaProxyServiceImpl.java
@@ -29,7 +29,7 @@ public class KafkaProxyServiceImpl extends KafkaProxyServiceGrpc.KafkaProxyServi
 
   private static final Logger logger = LoggerFactory.getLogger(KafkaProxyServiceImpl.class);
 
-  private ClientPool clientPool;
+  private final ClientPool clientPool;
 
   @Inject
   public KafkaProxyServiceImpl(final ClientPool clientPool) {
@@ -71,7 +71,10 @@ public class KafkaProxyServiceImpl extends KafkaProxyServiceGrpc.KafkaProxyServi
     final KafkaProducerWrapper producerWrapper =
         clientPool.getProducerForClient(clientId); // handle null
     final ProduceResponse response;
-    final byte[] key = request.getMessage().getMessageKey().getBytes();
+    final byte[] key =
+        request.getMessage().getMessageKey() != null
+            ? request.getMessage().getMessageKey().getBytes()
+            : null;
     final byte[] messageContent = request.getMessage().getMessageContent().getBytes();
 
     if (request.getGetAcksAt().equals(GetAcksAt.CLIENT)) {

--- a/src/main/java/server/examples/AckedClient.java
+++ b/src/main/java/server/examples/AckedClient.java
@@ -1,0 +1,58 @@
+package server.examples;
+
+import static io.grpc.Metadata.ASCII_STRING_MARSHALLER;
+
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
+import io.grpc.stub.MetadataUtils;
+import java.util.Scanner;
+import org.kafkagrpcproxy.GetAcksAt;
+import org.kafkagrpcproxy.KafkaMessage;
+import org.kafkagrpcproxy.KafkaProxyServiceGrpc;
+import org.kafkagrpcproxy.ProduceRequest;
+import org.kafkagrpcproxy.ProduceResponse;
+import org.kafkagrpcproxy.RegisterProducerRequest;
+import org.kafkagrpcproxy.RegisterProducerResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AckedClient {
+
+  private static final Logger logger = LoggerFactory.getLogger(Client.class);
+
+  public static void main(String[] args) {
+    ManagedChannel channel =
+        ManagedChannelBuilder.forAddress("localhost", 9999).usePlaintext().build();
+    KafkaProxyServiceGrpc.KafkaProxyServiceBlockingStub stub =
+        KafkaProxyServiceGrpc.newBlockingStub(channel);
+
+    RegisterProducerResponse registerClientResponse =
+        stub.registerProducer(RegisterProducerRequest.newBuilder().build());
+    final String clientId = registerClientResponse.getClientId();
+    logger.info("I am client: " + clientId);
+
+    Metadata.Key<String> clientIdKey = Metadata.Key.of("clientId", ASCII_STRING_MARSHALLER);
+    Metadata fixedHeaders = new Metadata();
+    fixedHeaders.put(clientIdKey, clientId);
+    stub = MetadataUtils.attachHeaders(stub, fixedHeaders);
+    Scanner in = new Scanner(System.in);
+    while (in.hasNextLine()) {
+      String msg = in.nextLine();
+      ProduceResponse response =
+          stub.produce(
+              ProduceRequest.newBuilder()
+                  .setMessage(
+                      KafkaMessage.newBuilder().setMessageKey("key").setMessageContent(msg).build())
+                  .setGetAcksAt(GetAcksAt.CLIENT)
+                  .build());
+      logger.info(
+          "Response from Kafka server.Proxy: "
+              + response.getResponseCode().toString()
+              + " "
+              + response.getOffset());
+    }
+
+    channel.shutdown();
+  }
+}

--- a/src/main/java/server/examples/AsyncProducerClient.java
+++ b/src/main/java/server/examples/AsyncProducerClient.java
@@ -56,7 +56,7 @@ public class AsyncProducerClient {
 
           @Override
           public void onCompleted() {
-
+              
           }
         };
 

--- a/src/main/proto/KafkaProxy.proto
+++ b/src/main/proto/KafkaProxy.proto
@@ -28,19 +28,13 @@ message RegisterConsumerResponse {
 
 message ProduceRequest {
     KafkaMessage message = 1;
+    GetAcksAt getAcksAt = 2;
 }
 
 message ProduceResponse {
     ResponseCode responseCode = 1;
     int64 offset = 2;
-}
-
-message ProduceFastAckRequest {
-    KafkaMessage message = 1;
-}
-
-message ProduceFastAckResponse {
-    ResponseCode responseCode = 1;
+    int64 timestamp = 3;
 }
 
 message ConsumeRequest {
@@ -62,9 +56,13 @@ enum ResponseCode {
     FAILED = 1;
 }
 
+enum GetAcksAt {
+    PROXY = 0; // DEFAULT
+    CLIENT = 4;
+}
+
 service KafkaProxyService {
     rpc produce(ProduceRequest) returns (ProduceResponse);
-    rpc produceFastAck(ProduceFastAckRequest) returns (ProduceFastAckResponse);
     rpc registerProducer(RegisterProducerRequest) returns (RegisterProducerResponse);
     rpc registerConsumer(RegisterConsumerRequest) returns (RegisterConsumerResponse);
     rpc consume(ConsumeRequest) returns (ConsumeResponse);


### PR DESCRIPTION
…where they get ACKs for the messages they produce.

Client: Client gets the acks and the response is not sent until Proxy gets ACKs from all replicas.
Proxy: Proxy gets the acks and does not forward it to the client. Client request succeeds, as long as the request to *proxy* is successful.