### PR TITLE
Add simple failover logic based on a change in endpoint discoverer.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,12 +109,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>${argLine.leak} ${argLine.alpnAgent} ${argLine.coverage}</argLine>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>

--- a/src/main/java/server/KafkaProxyServiceImpl.java
+++ b/src/main/java/server/KafkaProxyServiceImpl.java
@@ -41,7 +41,7 @@ public class KafkaProxyServiceImpl extends KafkaProxyServiceGrpc.KafkaProxyServi
       final RegisterProducerRequest request,
       final StreamObserver<RegisterProducerResponse> responseObserver) {
     final String uuid = UUID.randomUUID().toString();
-    clientPool.createProducerForClient(uuid, "test");
+    clientPool.createProducerForClient(uuid, "failover");
 
     final RegisterProducerResponse response =
         RegisterProducerResponse.newBuilder().setClientId(uuid).build();
@@ -54,7 +54,7 @@ public class KafkaProxyServiceImpl extends KafkaProxyServiceGrpc.KafkaProxyServi
       final RegisterConsumerRequest request,
       final StreamObserver<RegisterConsumerResponse> responseObserver) {
     final String uuid = UUID.randomUUID().toString();
-    clientPool.createConsumerForClient(uuid, "test", request.getGroupId());
+    clientPool.createConsumerForClient(uuid, "failover", request.getGroupId());
 
     final RegisterConsumerResponse response =
         RegisterConsumerResponse.newBuilder().setClientId(uuid).build();

--- a/src/main/java/server/kafkautils/ClientPool.java
+++ b/src/main/java/server/kafkautils/ClientPool.java
@@ -19,12 +19,15 @@ public class ClientPool implements Runnable {
   private final ConcurrentHashMap<String, KafkaConsumerWrapper> kafkaConsumers;
   private final EndpointDiscoverer endpointDiscoverer;
   private final ScheduledExecutorService scheduledExecutorService;
+  private final KafkaClientFactory kafkaClientFactory;
 
   @Inject
-  public ClientPool(final EndpointDiscoverer endpointDiscoverer) {
+  public ClientPool(
+      final EndpointDiscoverer endpointDiscoverer, final KafkaClientFactory kafkaClientFactory) {
     this.kafkaProducers = new ConcurrentHashMap<>();
     this.kafkaConsumers = new ConcurrentHashMap<>();
     this.endpointDiscoverer = endpointDiscoverer;
+    this.kafkaClientFactory = kafkaClientFactory;
     scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
     scheduledExecutorService.scheduleAtFixedRate(this, 0, 5, TimeUnit.SECONDS);
   }
@@ -47,7 +50,7 @@ public class ClientPool implements Runnable {
 
   public KafkaProducerWrapper createProducerForClient(final String clientId, final String topic) {
     final KafkaProducerWrapper newProducer =
-        new KafkaProducerWrapper(topic, "user_id", endpointDiscoverer);
+        new KafkaProducerWrapper(topic, "user_id", endpointDiscoverer, kafkaClientFactory);
     kafkaProducers.put(clientId, newProducer);
     return newProducer;
   }

--- a/src/main/java/server/kafkautils/KafkaClientFactory.java
+++ b/src/main/java/server/kafkautils/KafkaClientFactory.java
@@ -1,0 +1,30 @@
+package server.kafkautils;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+
+@Singleton
+public class KafkaClientFactory {
+
+  @Inject
+  public KafkaClientFactory() {
+
+  }
+
+  public KafkaProducer<byte[], byte[]> getProducer(final String endpoints) {
+    Map<String, Object> kafkaConfig = new HashMap<>();
+    kafkaConfig.put(ProducerConfig.ACKS_CONFIG, "all");
+    kafkaConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, endpoints);
+    kafkaConfig.put(
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+    kafkaConfig.put(
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+
+    return new KafkaProducer<>(kafkaConfig);
+  }
+}

--- a/src/main/java/server/modules/KafkaProxyModule.java
+++ b/src/main/java/server/modules/KafkaProxyModule.java
@@ -14,6 +14,7 @@ import server.discovery.EndpointDiscoverer;
 import server.discovery.FileBasedEndpointDiscoverer;
 import server.interceptors.ClientIdInterceptor;
 import server.kafkautils.ClientPool;
+import server.kafkautils.KafkaClientFactory;
 
 @Module
 public class KafkaProxyModule {
@@ -26,8 +27,9 @@ public class KafkaProxyModule {
   }
 
   @Provides
-  public static ClientPool provideClientPool(final EndpointDiscoverer endpointDiscoverer) {
-    return new ClientPool(endpointDiscoverer);
+  public static ClientPool provideClientPool(
+      final EndpointDiscoverer endpointDiscoverer, final KafkaClientFactory kafkaClientFactory) {
+    return new ClientPool(endpointDiscoverer, kafkaClientFactory);
   }
 
   @Provides
@@ -53,6 +55,11 @@ public class KafkaProxyModule {
   @Provides
   public static KafkaProxyServiceImpl provideKafkaProxyServiceImp(final ClientPool clientPool) {
     return new KafkaProxyServiceImpl(clientPool);
+  }
+
+  @Provides
+  public static KafkaClientFactory kafkaClientFactory() {
+    return new KafkaClientFactory();
   }
 
   @Provides

--- a/src/main/resources/cluster-coordinates/cluster-coordinates.yaml
+++ b/src/main/resources/cluster-coordinates/cluster-coordinates.yaml
@@ -1,5 +1,5 @@
 topics:
-  test:
+  failover:
     user_id: 'localhost:9092'
     user_id2: 'localhost:9093'
   test2:


### PR DESCRIPTION
Underlying producer assumes the cluster is still available and calls "close" upon receipt of the new signal.